### PR TITLE
feat: use gomodUpdateImportPaths

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,6 +27,14 @@
          "matchUpdateTypes": [
             "digest"
          ]
+      },
+      {
+         "matchDatasources": [
+            "go"
+         ],
+         "postUpdateOptions": [
+            "gomodUpdateImportPaths"
+         ]
       }
    ],
    "regexManagers": [

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -1,15 +1,24 @@
-local automerge = import 'automerge.jsonnet';
-local renovatePreset = import 'renovate-preset.jsonnet';
-local tflint = import 'tflint.jsonnet';
-local slsaGitHubGenerator = import 'slsa-github-generator.jsonnet';
 local actionSemver = import 'action-semver.jsonnet';
+local automerge = import 'automerge.jsonnet';
 local disableDigest = import 'disable-digest.jsonnet';
+local renovatePreset = import 'renovate-preset.jsonnet';
+local slsaGitHubGenerator = import 'slsa-github-generator.jsonnet';
+local tflint = import 'tflint.jsonnet';
 
 {
   extends: [
-    "helpers:pinGitHubActionDigests",
+    'helpers:pinGitHubActionDigests',
   ],
 } + automerge + {
-  packageRules: slsaGitHubGenerator.packageRules + actionSemver.packageRules + disableDigest.packageRules,
+  packageRules: slsaGitHubGenerator.packageRules + actionSemver.packageRules + disableDigest.packageRules + [
+    {
+      matchDatasources: [
+        'go',
+      ],
+      postUpdateOptions: [
+        'gomodUpdateImportPaths',
+      ],
+    },
+  ],
   regexManagers: tflint.regexManagers + renovatePreset.regexManagers,
 }


### PR DESCRIPTION
- https://docs.renovatebot.com/configuration-options/#postupdateoptions
- https://github.com/renovatebot/renovate/releases/tag/24.96.0
- https://github.com/renovatebot/renovate/pull/9144

> Update source import paths on major module updates, using mod.