### PR TITLE
fix: migrate customManager fileMatch to managerFilePatterns

### DIFF
--- a/action-go-version.json
+++ b/action-go-version.json
@@ -5,9 +5,9 @@
          "datasourceTemplate": "github-tags",
          "depNameTemplate": "golang/go",
          "extractVersionTemplate": "^go(?<version>.*)$",
-         "fileMatch": [
-            "^\\.github/workflows/.*\\.ya?ml$",
-            "^\\.github/actions/.*\\.ya?ml$"
+         "managerFilePatterns": [
+            "/^\\.github/workflows/.*\\.ya?ml$/",
+            "/^\\.github/actions/.*\\.ya?ml$/"
          ],
          "matchStrings": [
             "go-version: (?<currentValue>.*)",

--- a/default.json
+++ b/default.json
@@ -5,8 +5,8 @@
       {
          "customType": "regex",
          "datasourceTemplate": "github-releases",
-         "fileMatch": [
-            "\\.ya?ml$"
+         "managerFilePatterns": [
+            "/\\.ya?ml$/"
          ],
          "matchStrings": [
             "# yaml-language-server: \\$schema=https://raw\\.githubusercontent\\.com/(?<packageName>[^/:# \\n]+/[^/:# \\n]+)/(?<currentValue>[^/\" \\n\\(]+)/.*\\.json"

--- a/jsonnet/action-go-version.jsonnet
+++ b/jsonnet/action-go-version.jsonnet
@@ -2,9 +2,9 @@
   customManagers: [
     {
       customType: 'regex',
-      fileMatch: [
-        '^\\.github/workflows/.*\\.ya?ml$',
-        '^\\.github/actions/.*\\.ya?ml$',
+      managerFilePatterns: [
+        '/^\\.github/workflows/.*\\.ya?ml$/',
+        '/^\\.github/actions/.*\\.ya?ml$/',
       ],
       depNameTemplate: 'golang/go',
       datasourceTemplate: 'github-tags',

--- a/jsonnet/yaml-language-server.jsonnet
+++ b/jsonnet/yaml-language-server.jsonnet
@@ -3,8 +3,8 @@
     {
       customType: 'regex',
       datasourceTemplate: 'github-releases',
-      fileMatch: [
-        '\\.ya?ml$',
+      managerFilePatterns: [
+        '/\\.ya?ml$/',
       ],
       matchStrings: [
         '# yaml-language-server: \\$schema=https://raw\\.githubusercontent\\.com/(?<packageName>[^/:# \\n]+/[^/:# \\n]+)/(?<currentValue>[^/" \\n\\(]+)/.*\\.json',

--- a/yaml-language-server.json
+++ b/yaml-language-server.json
@@ -3,8 +3,8 @@
       {
          "customType": "regex",
          "datasourceTemplate": "github-releases",
-         "fileMatch": [
-            "\\.ya?ml$"
+         "managerFilePatterns": [
+            "/\\.ya?ml$/"
          ],
          "matchStrings": [
             "# yaml-language-server: \\$schema=https://raw\\.githubusercontent\\.com/(?<packageName>[^/:# \\n]+/[^/:# \\n]+)/(?<currentValue>[^/\" \\n\\(]+)/.*\\.json"


### PR DESCRIPTION
## Why

`renovate-config-validator --strict` (latest renovate) fails on every PR with **"Config migration necessary"** because the customManagers still use the deprecated `fileMatch` field. This blocks all open Renovate PRs in this repo (#953–#957).

## What

- Migrate the jsonnet sources (`yaml-language-server.jsonnet`, `action-go-version.jsonnet`) from `fileMatch` to `managerFilePatterns` (regex values wrapped in `/.../`).
- Regenerate the JSON via `bash scripts/generate.sh` (`default.json`, `action-go-version.json`, `yaml-language-server.json`).

## Test

```
$ npx --yes --package renovate@latest -c "renovate-config-validator --strict <files>"
 INFO: Config validated successfully against 11 file(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)