### PR TITLE
feat: hold typescript at v6

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,6 +65,12 @@
          ]
       },
       {
+         "allowedVersions": "<= 6",
+         "matchPackageNames": [
+            "typescript"
+         ]
+      },
+      {
          "matchPackageNames": [
             "!/^suzuki-shunsuke//",
             "!/^aquaproj//",

--- a/jsonnet/default.jsonnet
+++ b/jsonnet/default.jsonnet
@@ -31,6 +31,13 @@ local yamlLangServer = import 'yaml-language-server.jsonnet';
       automerge: true,
     },
     {
+      // @vercel/ncc bundles a ts-loader that drives the old JavaScript
+      // TypeScript API, which TypeScript 7 (the Go rewrite) no longer exposes,
+      // so JavaScript Actions built with ncc can't compile with it.
+      matchPackageNames: ['typescript'],
+      allowedVersions: '<= 6',
+    },
+    {
       matchPackageNames: [
         '!/^suzuki-shunsuke//',
         '!/^aquaproj//',


### PR DESCRIPTION
Holds `typescript` at v6 in the base preset so Renovate stops opening major update PRs that cannot pass CI.

`@vercel/ncc` bundles a `ts-loader` that drives the old JavaScript TypeScript API. TypeScript 7 is the Go rewrite and no longer exposes that API surface, so every JavaScript Action built with ncc fails with:

```
Error: Module build failed (from ./node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js):
TypeError: Cannot read properties of undefined (reading 'fileExists')
```

Seven Renovate PRs were failing this way and have been closed.

The rule goes in the base preset rather than `js-action` because four of the seven affected repositories do not extend `js-action`. It is a no-op for repositories without a `typescript` dependency.

Remove this rule once ncc supports TypeScript 7.

Only `jsonnet/default.jsonnet` was edited; `default.json` is the output of `scripts/generate.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)